### PR TITLE
Allow modification of uid and gid via --env

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -23,11 +23,14 @@ ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
     LANGUAGE=C.UTF-8
 
+COPY set-home-permissions.sh /etc/my_init.d/set-home-permissions.sh
+
 # Add a new user
 RUN adduser --disabled-password --gecos "" aster && \
     adduser aster sudo && \
     echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-    rm /etc/my_init.d/10_syslog-ng.init
+    rm /etc/my_init.d/10_syslog-ng.init && \
+    chmod +x /etc/my_init.d/set-home-permissions.sh 
 
 # Create a sharable zone
 USER aster

--- a/base/set-home-permissions.sh
+++ b/base/set-home-permissions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# User can pass e.g. --env HOST_UID=1003 so that UID in the container matches
+# with the UID on the host.
+if [ "$HOST_UID" ]; then
+    usermod -u $HOST_UID aster
+fi
+if [ "$HOST_GID" ]; then
+    groupmod -g $HOST_GID aster
+fi


### PR DESCRIPTION
When running ``docker run -ti --rm -v $(pwd):/home/aster/shared -w /home/aster/shared quay.io/tianyikillua/code_aster`` with an user whose id is not 1000, there are permission errors who don't allow modifications.

I added a small script `set-home-permissions.sh` so the user can pass the `HOST_UID` and `HOST_GID` with the `--env` command line option. 

This changes are based on the [fenics-project dockerfiles.](https://bitbucket.org/fenics-project/docker) 